### PR TITLE
fix: skip invisible entities in data formatter

### DIFF
--- a/src/classes/local/data_formatter.php
+++ b/src/classes/local/data_formatter.php
@@ -67,7 +67,7 @@ class data_formatter
         $methods = [];
         foreach ($raw as $entry) {
             $key = $entry['Entity'] ?? '';
-            if ($key === '') {
+            if ($key === '' || !($entry['IsVisible'] ?? false)) {
                 continue;
             }
             $methods[$key] = [

--- a/src/version.php
+++ b/src/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'paygw_ifthenpay';
-$plugin->version   = 2025091609;
+$plugin->version   = 2026012300;
 $plugin->requires  = 2023042400;
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.1.2';
+$plugin->release   = '1.1.3';


### PR DESCRIPTION
- Updated the data_formatter class to exclude entries where 'IsVisible' is not set or false, in addition to empty 'Entity' keys. This ensures only visible entities are processed.